### PR TITLE
introduce unified accounts for multichain settlements

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -79,20 +79,10 @@ func GetChannelByID(tx *gorm.DB, channelID string) (*Channel, error) {
 	return &channel, nil
 }
 
-// getChannelForParticipant finds the channel between a participant and the broker
-func getChannelForParticipant(tx *gorm.DB, participant string) (*Channel, error) {
-	var channel Channel
-	if err := tx.Where("participant_a = ? AND participant_b = ? AND status = ?",
-		participant, BrokerAddress, ChannelStatusOpen).Order("nonce DESC").First(&channel).Error; err != nil {
-		return nil, fmt.Errorf("no open channel found for participant %s: %w", participant, err)
-	}
-	return &channel, nil
-}
-
 // CheckExistingChannels checks if there is an existing open channel on the same network between participant A and B
-func CheckExistingChannels(tx *gorm.DB, participantA, participantB, networkID string) (*Channel, error) {
+func CheckExistingChannels(tx *gorm.DB, participantA, participantB, networkID, token string) (*Channel, error) {
 	var channel Channel
-	err := tx.Where("participant_a = ? AND participant_b = ? AND network_id = ? AND status = ?", participantA, participantB, networkID, ChannelStatusOpen).
+	err := tx.Where("participant_a = ? AND participant_b = ? AND network_id = ? AND token = ? AND status = ?", participantA, participantB, networkID, token, ChannelStatusOpen).
 		First(&channel).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {

--- a/docs/Broker.spec.md
+++ b/docs/Broker.spec.md
@@ -262,6 +262,9 @@ If authentication is successful, the server responds:
 ### Get Ledger Balances
 
 Retrieves the balances of all participants in a specific ledger account.
+- AccountID for unified balance is `asset+participant_address`, for example `"usdc0x123..."`.
+- AccountID for balance in a specific channel is `channelID`.
+- AccountID for balance in a specific virtual app is `vAppID`.
 
 **Request:**
 

--- a/vapp.go
+++ b/vapp.go
@@ -16,7 +16,7 @@ type VApp struct {
 	Status       ChannelStatus  `gorm:"column:status;not null"`
 	Challenge    uint64         `gorm:"column:challenge;"`
 	Nonce        uint64         `gorm:"column:nonce;not null"`
-	Token        string         `gorm:"column:token;not null"`
+	Asset        string         `gorm:"column:asset;not null"`
 	Weights      pq.Int64Array  `gorm:"type:integer[];column:weights"`
 	Quorum       uint64         `gorm:"column:quorum;default:100"`
 	Version      uint64         `gorm:"column:version;default:1"`


### PR DESCRIPTION
NOTE: use this PR in development for Multichain Ledger Development Branch

Description:

- The solution supports multiasset and multinetwork while keeping old RPC.
- Channels with broker: max one channel per token per network.
- vApps are limited to one asset per vApp, however, you can open multiple vApps, each different asset.
- user can deposit into one vApp from multiple chains
- user can withdraw on any chain

Frontend update guide:

- When creating vApp you should pass “usdc" into the token field.
- To fetch unified balance, you should pass “usdc+participantAddress” (“usdc0x12345”) into the "acc" field.
- Channel balance if fetched same as before.

**Now, ```participant_change``` in resize means how much you want to allocate from unified account into the channel on that network.**

> I you want to withdraw 100 from your unified balance, and your channel balance on the target chain channel is 0, then you have to call resize with participant change -100 on that network.

> If your channel balance on the target network is 20, and you want to withdraw 100 from your unified balance, then you need to call resize with participant change -80. 
